### PR TITLE
Reorganize input variables

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,11 +3,19 @@ resource "grafana_folder" "this" {
 }
 
 resource "grafana_rule_group" "this" {
-  for_each           = { for group in var.static_rule_groups : group.name => group }
-  name               = each.value.name
-  folder_uid         = grafana_folder.this.uid
-  interval_seconds   = each.value.interval_seconds
-  disable_provenance = !try(each.value.enable_edit, false)
+  for_each   = { for group in var.static_rule_groups : group.name => group }
+  name       = each.value.name
+  folder_uid = grafana_folder.this.uid
+  interval_seconds = try(
+    var.rule_groups["${each.value.name}"].interval_seconds,
+    each.value.interval_seconds
+  )
+  disable_provenance = try(
+    coalesce(
+      try(var.rule_groups["${each.value.name}"].editable, null),
+      var.editable,
+      try(each.value.editable, null)
+  ), null)
 
   dynamic "rule" {
     for_each = { for rule in each.value.rules : rule.name => rule }
@@ -21,35 +29,35 @@ resource "grafana_rule_group" "this" {
       annotations = merge(
         try(rule.value.annotations, null),
         try(var.annotations, null),
-        try(var.rule_groups.annotations, null),
-        try(var.rule_groups.rule_group["${each.key}"].annotations, null),
-        try(var.rule_groups.rule_group["${each.key}"].rule["${rule.key}"].annotations, null)
+        try(var.rule_groups["${each.key}"].annotations, null),
+        try(var.rule_groups["${each.key}"].rules["${rule.key}"].annotations, null)
       )
       labels = merge(
         try(rule.value.labels, null),
         try(var.labels, null),
-        try(var.rule_groups.labels, null),
-        try(var.rule_groups.rule_group["${each.key}"].labels, null),
-        try(var.rule_groups.rule_group["${each.key}"].rule["${rule.key}"].labels, null)
+        try(var.rule_groups["${each.key}"].labels, null),
+        try(var.rule_groups["${each.key}"].rules["${rule.key}"].labels, null)
       )
-      is_paused = (
-        try(rule.value.pause,
-          try(var.rule_groups.rule_group["${each.key}"].rule["${rule.key}"].pause,
-            try(var.rule_groups.rule_group["${each.key}"].pause,
-              try(var.rule_groups.pause, false)
-            )
-          )
-        )
-      )
+      is_paused = try(
+        coalesce(
+          try(var.rule_groups["${each.key}"].rules["${rule.key}"].pause, null),
+          try(var.rule_groups["${each.key}"].pause, null),
+          var.pause,
+          try(rule.value.pause, null)
+      ), null)
+
+
       dynamic "notification_settings" {
-        for_each = (
-          try([var.rule_groups.rule_group["${each.key}"].rule["${rule.key}"].notification_settings],
-            try([var.rule_groups.rule_group["${each.key}"].notification_settings],
-              try([var.rule_groups.notification_settings],
-                try([rule.value.notification_settings], [])
-              )
+        for_each = try(
+          [
+            coalesce(
+              try(var.rule_groups["${each.key}"].rules["${rule.key}"].notification_settings, null),
+              try(var.rule_groups["${each.key}"].notification_settings, null),
+              var.notification_settings,
+              try(rule.value.notification_settings, null)
             )
-          )
+          ],
+          []
         )
         iterator = notification_settings
         content {

--- a/schema.json
+++ b/schema.json
@@ -13,6 +13,14 @@
         "description": "The interval, in seconds, at which all rules in the group are evaluated. If a group contains many rules, the rules are evaluated sequentially.",
         "type": "integer"
       },
+      "editable": {
+        "description": "Allow modifying the rule group from other sources than Terraform or the Grafana API.",
+        "type": "boolean",
+        "enum": [
+          true,
+          false
+        ]
+      },
       "rules": {
         "description": " The rules within the group.",
         "type": "array",

--- a/variables.tf
+++ b/variables.tf
@@ -17,12 +17,35 @@ variable "datasource_uid" {
   default = ""
 }
 
+variable "pause" {
+  type    = bool
+  default = null
+}
+
+variable "editable" {
+  type    = bool
+  default = null
+}
+
+variable "notification_settings" {
+  type = object({
+    contact_point   = string
+    group_by        = optional(list(string))
+    group_interval  = optional(string)
+    group_wait      = optional(string)
+    mute_timings    = optional(list(string))
+    repeat_interval = optional(string)
+  })
+  default = null
+}
+
 variable "static_rule_groups" {
   type = any
 }
 
 variable "rule_groups" {
-  type = any
+  type    = any
+  default = {}
 }
 
 locals {


### PR DESCRIPTION
### Description
The changes is meant to take some rules_groups varaible to terraform layer, and simplify the strucute. 
Also notice the `rule_groups.rule` it changed to `rule_groups.rules` to be consistent with schema.

**Original Structure:**
```tf 
rule_groups = {
  annotations = {}
  labels = {}
  pause = false
  notification_settings = {}
  
  rule_group = {
    "group-name" = {
      rule = {
        "rule-name" = {}
    }
  }
}
```

**New Structure:**
```tf
rule_groups = {
  "group-name" = {
    rules = {
      "rule-name" = {}
  }
}
```

### Breaking change
- Moved global overwitten variables (`pause`, `editable`, `notification_settings`) from `rule_groups` to Terraform variables.

### Change
- Supported customize `interval_seconds` in each rule_group.
- Included `editable` variable in schema and added it as a configurable option within each rule_group.
- Refactored some internal logic